### PR TITLE
Typo: Change 'he' to 'be'

### DIFF
--- a/src/epub/text/chapter-32.xhtml
+++ b/src/epub/text/chapter-32.xhtml
@@ -91,7 +91,7 @@
 			<p>“So did I. Do you think I could explain if I would?”</p>
 			<p>“No, I suppose not. Well,” he added, “I’ve done what I wished. I’ve seen you.”</p>
 			<p>“How little you make of these terrible journeys,” she felt the poverty of her presently replying.</p>
-			<p>“If you’re afraid I’m knocked up⁠—in any such way as that⁠—you may he at your ease about it.” He turned away, this time in earnest, and no handshake, no sign of parting, was exchanged between them.</p>
+			<p>“If you’re afraid I’m knocked up⁠—in any such way as that⁠—you may be at your ease about it.” He turned away, this time in earnest, and no handshake, no sign of parting, was exchanged between them.</p>
 			<p>At the door he stopped with his hand on the knob. “I shall leave Florence tomorrow,” he said without a quaver.</p>
 			<p>“I’m delighted to hear it!” she answered passionately. Five minutes after he had gone out she burst into tears.</p>
 		</section>


### PR DESCRIPTION
This appears to be a typo, or an OCR error.